### PR TITLE
PR: add command-line help message for zn_sub_thr_stream.rs

### DIFF
--- a/throughput/src/bin/zn_sub_thr_stream.rs
+++ b/throughput/src/bin/zn_sub_thr_stream.rs
@@ -27,17 +27,26 @@ use zenoh::{
 #[derive(Debug, Parser)]
 #[clap(name = "zn_sub_thr_stream")]
 struct Opt {
+    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long, value_delimiter = ',')]
     locator: Vec<Locator>,
+
+    /// peer, router, or client
     #[clap(short, long)]
     mode: String,
+
+    /// payload size (bytes)
     #[clap(short, long)]
     payload: usize,
+
     #[clap(short, long)]
     name: String,
+
     #[clap(short, long)]
     scenario: String,
-    #[clap(long = "conf", parse(from_os_str))]
+
+    /// configuration file (json5 or yaml)
+    #[clap(long = "conf")]
     config: Option<PathBuf>,
 }
 


### PR DESCRIPTION
This PR is to add command-line help message for zn_sub_thr_stream.rs

- [x]  align with Yuan's zn_sub_thr.rs for the help messages
- [x]  verified with the following commands
`$ ./target/debug/zn_sub_thr_stream -s my-test -m peer -l tcp/localhost:7447 -p 8 -n now`
`$ ./target/debug/zn_pub_thr -m peer -l tcp/localhost:7447 -p 8`
