### PR TITLE
PR: rename option --declare-expr to --use-expr

### DIFF
--- a/throughput/src/bin/z_sub_thr.rs
+++ b/throughput/src/bin/z_sub_thr.rs
@@ -50,11 +50,11 @@ struct Opt {
     config: Option<PathBuf>,
 
     /// declare a numerical Id for the subscribed key expression
-    #[clap(long = "declare-expr")]
+    #[clap(long)]
     use_expr: bool,
 
     /// do not use callback for subscriber
-    #[clap(long = "no-callback")]
+    #[clap(long)]
     no_callback: bool,
 }
 


### PR DESCRIPTION
This PR is to rename the command-line option --declare-expr to --use-expr.

- [x] verified with the following commands for the new --use-expr option
`$ ./target/debug/z_sub_thr -s my-test -m peer -l tcp/localhost:7447 -p 8 -n now --use-expr`
`$ ./target/debug/z_put_thr -m peer -l tcp/localhost:7447 -p 8`
