### PR TITLE
Finished porting of t_pub_thr & t_sub_thr and use patch to specify the zenoh version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ lto="fat"
 codegen-units=1
 opt-level=3
 panic="abort"
+
+[patch.crates-io]
+zenoh                = {git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "6de43038123e622c9a69ddc1d5c881f844728475"}
+zenoh-util           = {git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "6de43038123e622c9a69ddc1d5c881f844728475"}
+zenoh-core           = {git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "6de43038123e622c9a69ddc1d5c881f844728475"}
+zenoh-cfg-properties = {git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "6de43038123e622c9a69ddc1d5c881f844728475"}
+zenoh-protocol-core  = {git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "6de43038123e622c9a69ddc1d5c881f844728475"}

--- a/throughput/Cargo.toml
+++ b/throughput/Cargo.toml
@@ -45,33 +45,3 @@ zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba3
 zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
 zenoh-protocol-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
 clap = { version = "3.1.5", features = ["derive"] }
-
-[[bin]]
-name = "t_pub_thr"
-
-[[bin]]
-name = "t_sub_thr"
-
-[[bin]]
-name = "t_pubsub_thr"
-
-[[bin]]
-name = "t_router_thr"
-
-[[bin]]
-name = "t_sink_tcp"
-
-[[bin]]
-name = "t_sink_udp"
-
-[[bin]]
-name = "r_pub_thr"
-
-[[bin]]
-name = "r_sub_thr"
-
-[[bin]]
-name = "z_put_thr"
-
-[[bin]]
-name = "z_sub_thr"

--- a/throughput/Cargo.toml
+++ b/throughput/Cargo.toml
@@ -39,9 +39,9 @@ log = "0.4.14"
 rand = "0.8.5"
 slab = "0.4.5"
 json5 = "0.4.1"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea", default-features = false, features = ["transport_tcp", "transport_udp"] }
-zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
-zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
-zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
-zenoh-protocol-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
+zenoh = { version="0.6.0-dev", default-features = false, features = ["transport_tcp", "transport_udp"] }
+zenoh-util = "0.6.0-dev"
+zenoh-core = "0.6.0-dev"
+zenoh-cfg-properties = "0.6.0-dev"
+zenoh-protocol-core = "0.6.0-dev"
 clap = { version = "3.1.5", features = ["derive"] }

--- a/throughput/Cargo.toml
+++ b/throughput/Cargo.toml
@@ -39,8 +39,11 @@ log = "0.4.14"
 rand = "0.8.5"
 slab = "0.4.5"
 json5 = "0.4.1"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "9b7338b46ce2f317086db1ceb7f54fd5dd29af54", default-features = false, features = ["transport_tcp", "transport_udp"] }
-zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "9b7338b46ce2f317086db1ceb7f54fd5dd29af54" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea", default-features = false, features = ["transport_tcp", "transport_udp"] }
+zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
+zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
+zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
+zenoh-protocol-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "641ba35a60e0d49f1aeecd854e5028ecde3da8ea" }
 clap = { version = "3.1.5", features = ["derive"] }
 
 [[bin]]

--- a/throughput/src/bin/t_pub_thr.rs
+++ b/throughput/src/bin/t_pub_thr.rs
@@ -11,25 +11,31 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-use async_std::sync::Arc;
-use async_std::task;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
-use structopt::StructOpt;
-use zenoh::net::link::EndPoint;
-use zenoh::net::protocol::core::{
-    whatami, Channel, CongestionControl, Priority, Reliability, ResKey,
+use async_std::{sync::Arc, task};
+use clap::Parser;
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
 };
-use zenoh::net::protocol::io::ZBuf;
-use zenoh::net::protocol::proto::ZenohMessage;
-use zenoh::net::transport::{
-    DummyTransportPeerEventHandler, TransportEventHandler, TransportManager,
-    TransportManagerConfig, TransportMulticast, TransportMulticastEventHandler, TransportPeer,
-    TransportPeerEventHandler, TransportUnicast,
+use zenoh::net::{
+    link::EndPoint,
+    protocol::{
+        core::{Channel, CongestionControl, Priority, Reliability},
+        io::ZBuf,
+        proto::ZenohMessage,
+    },
+    transport::{
+        DummyTransportPeerEventHandler, TransportEventHandler, TransportManager,
+        TransportMulticast, TransportMulticastEventHandler, TransportPeer,
+        TransportPeerEventHandler, TransportUnicast,
+    },
 };
-use zenoh_util::core::ZResult;
-use zenoh_util::properties::{IntKeyProperties, Properties};
+use zenoh::{
+    config::{Config, WhatAmI},
+    prelude::KeyExpr,
+};
+use zenoh_core::zresult::ZResult;
 
 struct MySH {}
 
@@ -56,18 +62,27 @@ impl TransportEventHandler for MySH {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "s_pub_thr")]
+#[derive(Debug, Parser)]
+#[clap(name = "s_pub_thr")]
 struct Opt {
-    #[structopt(short = "c", long = "connect")]
-    connect: Vec<EndPoint>,
-    #[structopt(short = "m", long = "mode")]
-    mode: String,
-    #[structopt(short = "p", long = "payload")]
+    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    #[clap(short, long, value_delimiter = ',')]
+    locator: Vec<EndPoint>,
+
+    /// peer, router, or client
+    #[clap(short, long)]
+    mode: WhatAmI,
+
+    /// payload size (bytes)
+    #[clap(short, long)]
     payload: usize,
-    #[structopt(short = "t", long = "print")]
+
+    /// print the counter
+    #[clap(short = 't', long)]
     print: bool,
-    #[structopt(long = "conf", parse(from_os_str))]
+
+    /// configuration file (json5 or yaml)
+    #[clap(long = "conf", parse(from_os_str))]
     config: Option<PathBuf>,
 }
 
@@ -77,28 +92,28 @@ async fn main() {
     env_logger::init();
 
     // Parse the args
-    let opt = Opt::from_args();
+    let Opt {
+        locator,
+        mode,
+        payload,
+        print,
+        config,
+    } = Opt::parse();
 
-    let whatami = whatami::parse(opt.mode.as_str()).unwrap();
-
-    let bc = match opt.config.as_ref() {
-        Some(f) => {
-            let config = async_std::fs::read_to_string(f).await.unwrap();
-            let properties = Properties::from(config);
-            let int_props = IntKeyProperties::from(properties);
-            TransportManagerConfig::builder()
-                .from_config(&int_props)
-                .await
-                .unwrap()
-        }
-        None => TransportManagerConfig::builder().whatami(whatami),
+    // Setup TransportManager
+    let builder = match config {
+        Some(path) => TransportManager::builder()
+            .from_config(&Config::from_file(path).unwrap())
+            .await
+            .unwrap(),
+        None => TransportManager::builder().whatami(mode),
     };
-    let config = bc.build(Arc::new(MySH::new()));
-    let manager = TransportManager::new(config);
+    let handler = Arc::new(MySH::new());
+    let manager = builder.build(handler).unwrap();
 
     // Connect to publisher
     let mut transports: Vec<TransportUnicast> = vec![];
-    for e in opt.connect.iter() {
+    for e in locator {
         let t = manager.open_transport_unicast(e.clone()).await.unwrap();
         transports.push(t);
     }
@@ -109,15 +124,15 @@ async fn main() {
         reliability: Reliability::Reliable,
     };
     let congestion_control = CongestionControl::Block;
-    let key = ResKey::RId(1);
+    let key = KeyExpr::from(1);
     let info = None;
-    let payload = ZBuf::from(vec![0u8; opt.payload]);
+    let payload = ZBuf::from(vec![0u8; payload]);
     let reply_context = None;
     let routing_context = None;
     let attachment = None;
 
     let count = Arc::new(AtomicUsize::new(0));
-    if opt.print {
+    if print {
         let c_count = count.clone();
         task::spawn(async move {
             loop {

--- a/throughput/src/bin/t_pub_thr.rs
+++ b/throughput/src/bin/t_pub_thr.rs
@@ -65,9 +65,9 @@ impl TransportEventHandler for MySH {
 #[derive(Debug, Parser)]
 #[clap(name = "s_pub_thr")]
 struct Opt {
-    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long, value_delimiter = ',')]
-    locator: Vec<EndPoint>,
+    endpoint: Vec<EndPoint>,
 
     /// peer, router, or client
     #[clap(short, long)]
@@ -93,7 +93,7 @@ async fn main() {
 
     // Parse the args
     let Opt {
-        locator,
+        endpoint,
         mode,
         payload,
         print,
@@ -113,7 +113,7 @@ async fn main() {
 
     // Connect to publisher
     let mut transports: Vec<TransportUnicast> = vec![];
-    for e in locator {
+    for e in endpoint {
         let t = manager.open_transport_unicast(e.clone()).await.unwrap();
         transports.push(t);
     }

--- a/throughput/src/bin/t_sub_thr.rs
+++ b/throughput/src/bin/t_sub_thr.rs
@@ -120,9 +120,9 @@ impl TransportPeerEventHandler for MyMH {
 #[derive(Debug, Parser)]
 #[clap(name = "s_sub_thr")]
 struct Opt {
-    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long, value_delimiter = ',')]
-    locator: Vec<EndPoint>,
+    endpoint: Vec<EndPoint>,
 
     /// peer, router, or client
     #[clap(short, long)]
@@ -150,7 +150,7 @@ async fn main() {
 
     // Parse the args
     let Opt {
-        locator,
+        endpoint,
         mode,
         payload,
         name,
@@ -171,11 +171,11 @@ async fn main() {
     let manager = builder.build(handler).unwrap();
 
     if mode == WhatAmI::Peer {
-        for e in locator {
+        for e in endpoint {
             manager.add_listener(e.clone()).await.unwrap();
         }
     } else {
-        for e in locator {
+        for e in endpoint {
             let _t = manager.open_transport_unicast(e.clone()).await.unwrap();
         }
     }

--- a/throughput/src/bin/t_sub_thr.rs
+++ b/throughput/src/bin/t_sub_thr.rs
@@ -11,20 +11,21 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-use async_std::future;
-use async_std::sync::Arc;
-use async_std::task;
-use std::any::Any;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
-use structopt::StructOpt;
-use zenoh::net::link::{EndPoint, Link};
-use zenoh::net::protocol::core::whatami;
-use zenoh::net::protocol::proto::ZenohMessage;
-use zenoh::net::transport::*;
-use zenoh_util::core::ZResult;
-use zenoh_util::properties::{IntKeyProperties, Properties};
+use async_std::{future, sync::Arc, task};
+use clap::Parser;
+use std::{
+    any::Any,
+    path::PathBuf,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    time::{Duration, Instant},
+};
+use zenoh::config::{Config, WhatAmI};
+use zenoh::net::{
+    link::{EndPoint, Link},
+    protocol::proto::ZenohMessage,
+    transport::*,
+};
+use zenoh_core::zresult::ZResult;
 
 // Transport Handler for the peer
 struct MySH {
@@ -116,20 +117,29 @@ impl TransportPeerEventHandler for MyMH {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "s_sub_thr")]
+#[derive(Debug, Parser)]
+#[clap(name = "s_sub_thr")]
 struct Opt {
-    #[structopt(short = "e", long = "endpoint")]
-    endpoint: Vec<EndPoint>,
-    #[structopt(short = "m", long = "mode")]
-    mode: String,
-    #[structopt(short = "p", long = "payload")]
+    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    #[clap(short, long, value_delimiter = ',')]
+    locator: Vec<EndPoint>,
+
+    /// peer, router, or client
+    #[clap(short, long)]
+    mode: WhatAmI,
+
+    /// payload size (bytes)
+    #[clap(short, long)]
     payload: usize,
-    #[structopt(short = "n", long = "name")]
+
+    #[clap(short, long)]
     name: String,
-    #[structopt(short = "s", long = "scenario")]
+
+    #[clap(short, long)]
     scenario: String,
-    #[structopt(long = "conf", parse(from_os_str))]
+
+    /// configuration file (json5 or yaml)
+    #[clap(long = "conf", parse(from_os_str))]
     config: Option<PathBuf>,
 }
 
@@ -139,37 +149,33 @@ async fn main() {
     env_logger::init();
 
     // Parse the args
-    let opt = Opt::from_args();
+    let Opt {
+        locator,
+        mode,
+        payload,
+        name,
+        scenario,
+        config,
+    } = Opt::parse();
 
-    let whatami = whatami::parse(opt.mode.as_str()).unwrap();
-
+    // Setup TransportManager
     let count = Arc::new(AtomicUsize::new(0));
-    let bc = match opt.config.as_ref() {
-        Some(f) => {
-            let config = async_std::fs::read_to_string(f).await.unwrap();
-            let properties = Properties::from(config);
-            let int_props = IntKeyProperties::from(properties);
-            TransportManagerConfig::builder()
-                .from_config(&int_props)
-                .await
-                .unwrap()
-        }
-        None => TransportManagerConfig::builder().whatami(whatami::ROUTER),
+    let builder = match config {
+        Some(path) => TransportManager::builder()
+            .from_config(&Config::from_file(path).unwrap())
+            .await
+            .unwrap(),
+        None => TransportManager::builder().whatami(WhatAmI::Router),
     };
-    let config = bc.build(Arc::new(MySH::new(
-        opt.scenario,
-        opt.name,
-        opt.payload,
-        count,
-    )));
-    let manager = TransportManager::new(config);
+    let handler = Arc::new(MySH::new(scenario, name, payload, count));
+    let manager = builder.build(handler).unwrap();
 
-    if whatami == whatami::PEER {
-        for e in opt.endpoint.iter() {
+    if mode == WhatAmI::Peer {
+        for e in locator {
             manager.add_listener(e.clone()).await.unwrap();
         }
     } else {
-        for e in opt.endpoint.iter() {
+        for e in locator {
             let _t = manager.open_transport_unicast(e.clone()).await.unwrap();
         }
     }

--- a/throughput/src/bin/z_put_thr.rs
+++ b/throughput/src/bin/z_put_thr.rs
@@ -15,26 +15,22 @@ use async_std::{sync::Arc, task};
 use clap::Parser;
 use std::{
     path::PathBuf,
-    str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
-use zenoh::{
-    config::{whatami::WhatAmI, Config},
-    prelude::{Locator, Value},
-    publication::CongestionControl,
-};
+use zenoh::{config::Config, prelude::Value};
+use zenoh_protocol_core::{CongestionControl, EndPoint, WhatAmI};
 
 #[derive(Debug, Parser)]
 #[clap(name = "z_put_thr")]
 struct Opt {
     /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long, value_delimiter = ',')]
-    locator: Vec<Locator>,
+    locator: Vec<EndPoint>,
 
     /// peer, router, or client
     #[clap(short, long)]
-    mode: String,
+    mode: WhatAmI,
 
     /// payload size (bytes)
     #[clap(short, long)]
@@ -80,12 +76,10 @@ async fn main() {
         } else {
             Config::default()
         };
-        config
-            .set_mode(Some(WhatAmI::from_str(&mode).unwrap()))
-            .unwrap();
+        config.set_mode(Some(mode)).unwrap();
         config.set_add_timestamp(Some(false)).unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config.peers.extend(locator);
+        config.connect.endpoints.extend(locator);
         config
     };
 

--- a/throughput/src/bin/z_put_thr.rs
+++ b/throughput/src/bin/z_put_thr.rs
@@ -24,9 +24,9 @@ use zenoh_protocol_core::{CongestionControl, EndPoint, WhatAmI};
 #[derive(Debug, Parser)]
 #[clap(name = "z_put_thr")]
 struct Opt {
-    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long, value_delimiter = ',')]
-    locator: Vec<EndPoint>,
+    endpoint: Vec<EndPoint>,
 
     /// peer, router, or client
     #[clap(short, long)]
@@ -62,7 +62,7 @@ async fn main() {
 
     // Parse the args
     let Opt {
-        locator,
+        endpoint,
         mode,
         payload,
         print,
@@ -79,7 +79,7 @@ async fn main() {
         config.set_mode(Some(mode)).unwrap();
         config.set_add_timestamp(Some(false)).unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config.connect.endpoints.extend(locator);
+        config.connect.endpoints.extend(endpoint);
         config
     };
 

--- a/throughput/src/bin/z_put_thr.rs
+++ b/throughput/src/bin/z_put_thr.rs
@@ -45,7 +45,7 @@ struct Opt {
     print: bool,
 
     /// configuration file (json5 or yaml)
-    #[clap(long = "conf")]
+    #[clap(long = "conf", parse(from_os_str))]
     config: Option<PathBuf>,
 
     /// declare a numerical Id for the publisher's key expression

--- a/throughput/src/bin/z_sub_thr.rs
+++ b/throughput/src/bin/z_sub_thr.rs
@@ -46,7 +46,7 @@ struct Opt {
     scenario: String,
 
     /// configuration file (json5 or yaml)
-    #[clap(long = "conf")]
+    #[clap(long = "conf", parse(from_os_str))]
     config: Option<PathBuf>,
 
     /// declare a numerical Id for the subscribed key expression

--- a/throughput/src/bin/z_sub_thr.rs
+++ b/throughput/src/bin/z_sub_thr.rs
@@ -24,9 +24,9 @@ use zenoh_protocol_core::{EndPoint, WhatAmI};
 #[derive(Debug, Parser)]
 #[clap(name = "z_sub_thr")]
 struct Opt {
-    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long, value_delimiter = ',')]
-    locator: Vec<EndPoint>,
+    endpoint: Vec<EndPoint>,
 
     /// peer, router, or client
     #[clap(short, long, possible_values = ["peer", "client"])]
@@ -64,7 +64,7 @@ async fn main() {
 
     // Parse the args
     let Opt {
-        locator,
+        endpoint,
         mode,
         payload,
         name,
@@ -83,8 +83,8 @@ async fn main() {
         config.set_mode(Some(mode)).unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         match mode {
-            WhatAmI::Peer => config.listen.endpoints.extend(locator),
-            WhatAmI::Client => config.connect.endpoints.extend(locator),
+            WhatAmI::Peer => config.listen.endpoints.extend(endpoint),
+            WhatAmI::Client => config.connect.endpoints.extend(endpoint),
             _ => panic!("Unsupported mode: {}", mode),
         };
         config


### PR DESCRIPTION
This PR consists of 

* Porting of t_pub_thr & t_sub_thr.
* Correct path reading function used in clap
* Update zenoh version and adapt the new API.
* Use patch to better specify zenoh version.

Benchmark of t_pub_thr & t_sub_thr

![throughput-comparison](https://user-images.githubusercontent.com/10692887/158854163-e465b1f2-87d8-416d-b5d6-0bbd94ad7fb8.jpeg)

