### PR TITLE
Update some zenoh usage

### DIFF
--- a/latency/Cargo.toml
+++ b/latency/Cargo.toml
@@ -39,8 +39,11 @@ log = "0.4.14"
 rand = "0.8.3"
 slab = "0.4.2"
 clap = { version = "3.1.5", features = ["derive"] }
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "9b7338b46ce2f317086db1ceb7f54fd5dd29af54", default-features = false, features = ["transport_tcp", "transport_udp"] }
-zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "9b7338b46ce2f317086db1ceb7f54fd5dd29af54" }
+zenoh = { version="0.6.0-dev", default-features = false, features = ["transport_tcp", "transport_udp"] }
+zenoh-util = "0.6.0-dev"
+zenoh-core = "0.6.0-dev"
+zenoh-cfg-properties = "0.6.0-dev"
+zenoh-protocol-core = "0.6.0-dev"
 
 [[bin]]
 name = "t_pub_delay"

--- a/latency/Cargo.toml
+++ b/latency/Cargo.toml
@@ -45,32 +45,3 @@ zenoh-core = "0.6.0-dev"
 zenoh-cfg-properties = "0.6.0-dev"
 zenoh-protocol-core = "0.6.0-dev"
 
-[[bin]]
-name = "t_pub_delay"
-
-[[bin]]
-name = "t_sub_delay"
-
-[[bin]]
-name = "t_ping"
-
-[[bin]]
-name = "t_pong"
-
-[[bin]]
-name = "r_ping"
-
-[[bin]]
-name = "r_pong"
-
-[[bin]]
-name = "zn_ping"
-
-[[bin]]
-name = "zn_pong"
-
-[[bin]]
-name = "z_ping"
-
-[[bin]]
-name = "z_pong"

--- a/latency/src/bin/z_pong.rs
+++ b/latency/src/bin/z_pong.rs
@@ -15,18 +15,17 @@ use async_std::future;
 use async_std::stream::StreamExt;
 use clap::Parser;
 use zenoh::config::Config;
-use zenoh::net::protocol::core::WhatAmI;
-use zenoh::publication::CongestionControl;
+use zenoh_protocol_core::{CongestionControl, WhatAmI};
 
 #[derive(Debug, Parser)]
 #[clap(name = "z_pong")]
 struct Opt {
-    /// locator(s), e.g. --locator tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
+    /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
     #[clap(short, long)]
-    locator: String,
+    endpoint: String,
     
-    /// peer, router, or client
-    #[clap(short, long)]
+    /// peer or client
+    #[clap(short, long, possible_values = ["peer", "client"])]
     mode: String,
 }
 
@@ -43,14 +42,16 @@ async fn main() {
         "peer" => {
             config.set_mode(Some(WhatAmI::Peer)).unwrap();
             config
-                .listeners
-                .extend(opt.locator.split(',').map(|v| v.parse().unwrap()));
+                .listen
+                .endpoints
+                .extend(opt.endpoint.split(',').map(|v| v.parse().unwrap()));
         }
         "client" => {
             config.set_mode(Some(WhatAmI::Client)).unwrap();
             config
-                .peers
-                .extend(opt.locator.split(',').map(|v| v.parse().unwrap()));
+                .connect
+                .endpoints
+                .extend(opt.endpoint.split(',').map(|v| v.parse().unwrap()));
         }
         _ => panic!("Unsupported mode: {}", opt.mode),
     };


### PR DESCRIPTION
* Use patch to specify zenoh's version (latency crate)
* Remove redundant content in `Cargo.toml`
* Change "locator" to "endpoint"

- [x] Pass compilation with cargo build --bin `z_ping` (`z_pong`)
- [x] Verified by the following commands: `$ ./z_pong -e tcp/127.0.0.1:7447 -m peer`
` $ ./z_ping -m peer -p 16 -n none -s none -i 1 -e tcp/127.0.0.1:7447` 