### PR TITLE
Add option "use_expr"

### DIFF
--- a/latency/src/bin/z_pong.rs
+++ b/latency/src/bin/z_pong.rs
@@ -68,10 +68,18 @@ async fn main() {
     } else {
         session.subscribe("/test/ping").reliable().await.unwrap()
     };
+    let mut key_expr_pong = 0;
+    if opt.use_expr {
+        key_expr_pong = session.declare_expr("/test/pong").await.unwrap();
+    }
 
     while let Some(sample) = sub.next().await {
-                session
-                    .put("/test/pong", sample)
+                let writer = if opt.use_expr {
+                    session.put(key_expr_pong, sample)
+                } else {
+                    session.put("/test/pong", sample)
+                };
+                writer
                     .congestion_control(CongestionControl::Block)
                     .await
                     .unwrap();


### PR DESCRIPTION
* Add new option "use_expr" for z_ping/z_pong.rs
* Declare the subscriber outside the task and remove the barrier (in parallel mode)

- [x] Pass compilation with cargo build --bin z_ping (z_pong)

- [x] Verified by the following commands: `$ ./z_pong -e tcp/127.0.0.1:7447 -m peer --use-expr`
`$ ./z_ping -m peer -p 16 -n none -s none -i 1 -e tcp/127.0.0.1:7447 --use-expr`